### PR TITLE
Add compact representation (new default)

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -42,7 +42,7 @@ PlasmoidItem {
       MouseArea {
         hoverEnabled: true
         anchors.fill: parent
-        onEntered: root.expanded = true
+        onClicked: root.expanded = true
       }
     }
 
@@ -104,10 +104,6 @@ PlasmoidItem {
                 horizontalAlignment: Text.AlignRight
                 Layout.fillWidth: true
             }
-        }
-        MouseArea {
-          anchors.fill: parent
-          onExited: root.expanded = false
         }
     }
     


### PR DESCRIPTION
The current version is lacking compact representation -> users have to always click the icon in taskbar to view prices. Add compact representation to show the current price.